### PR TITLE
feat(keycloak): add HA deployment support with clustering configuration

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -1,0 +1,127 @@
+# ---------------- PostgreSQL ----------------
+postgres_port: 5432
+postgres_host: "localhost"
+
+keycloak_db_name: "keycloak"
+keycloak_db_user: "keycloak"
+keycloak_db_password: "change_me"
+
+# ---------------- Keycloak Versioning ----------------
+# Keycloak 17+ (Quarkus-based). Tested with 26.x
+keycloak_version: "26.0.7"
+
+keycloak_archive_name: "keycloak-{{ keycloak_version }}.tar.gz"
+
+keycloak_download_url: >
+  https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/{{ keycloak_archive_name }}
+
+# ---------------- Paths ----------------
+keycloak_base_dir: "/opt"
+keycloak_versions_dir: "{{ keycloak_base_dir }}"
+keycloak_install_dir: "/opt/keycloak"
+keycloak_tmp_dir: "/tmp"
+
+# ---------------- Database Control ----------------
+# DB provisioning should be external by default
+keycloak_manage_db: false
+
+
+# ---------------- Admin Bootstrap ----------------
+keycloak_admin_user: "admin"
+keycloak_admin_password: "change_me"
+
+# ---------------- Network ----------------
+keycloak_http_port: 8080
+keycloak_hostname: "localhost"
+
+# ---------------- Java ----------------
+# Keycloak requires Java 17+
+java_version: "21"
+
+# ---------------- System User ----------------
+keycloak_user: "keycloak"
+keycloak_group: "keycloak"
+
+# ---------------- TLS / HTTPS ----------------
+# Enable HTTPS directly in Keycloak
+keycloak_https_enabled: false
+
+# Used only if keycloak_https_enabled = true
+keycloak_https_port: 8443
+keycloak_tls_cert_file: ""
+keycloak_tls_key_file: ""
+
+# ---------------- Reverse Proxy ----------------
+# none | edge | reencrypt
+keycloak_proxy_mode: "none"
+
+# ---------------- Identity Providers (Optional) ----------------
+# Enable external authentication providers via realm import
+# Supported: OIDC, LDAP, SAML
+# All providers are disabled by default
+
+keycloak_identity_providers:
+  oidc: false
+  ldap: false
+  saml: false
+
+# ---------------- OIDC Identity Providers ----------------
+# Example: Google, Azure AD, Keycloak Broker, etc.
+# Used only if keycloak_identity_providers.oidc = true
+
+keycloak_oidc_providers: []
+# Example:
+# keycloak_oidc_providers:
+#   - alias: "google"
+#     display_name: "Google Login"
+#     issuer: "https://accounts.google.com"
+#     client_id: "xxxxx"
+#     client_secret: "yyyyy"
+#     default_scopes: "openid profile email"
+
+# ---------------- LDAP Identity Providers ----------------
+# Used only if keycloak_identity_providers.ldap = true
+
+keycloak_ldap_providers: []
+# Example:
+# keycloak_ldap_providers:
+#   - name: "corp-ldap"
+#     connection_url: "ldap://ldap.example.com"
+#     users_dn: "ou=users,dc=example,dc=com"
+#     bind_dn: "cn=admin,dc=example,dc=com"
+#     bind_credential: "ldap_password"
+
+# ---------------- SAML Identity Providers ----------------
+# Used only if keycloak_identity_providers.saml = true
+
+keycloak_saml_providers: []
+# Example:
+# keycloak_saml_providers:
+#   - alias: "corp-saml"
+#     entity_id: "https://idp.example.com/entity"
+#     single_sign_on_service_url: "https://idp.example.com/sso"
+#     signing_certificate: "/etc/keycloak/saml/idp.crt"
+
+# ---------------- High Availability (HA) ----------------
+
+keycloak_ha_enabled: false
+
+# Node identity (unique per node)
+keycloak_node_name: "{{ inventory_hostname }}"
+
+# Cache / clustering
+keycloak_cache_stack: "tcp"   # tcp | udp | kubernetes | dns
+
+# JGroups TCP discovery
+keycloak_jgroups_initial_hosts: []
+# Example:
+# keycloak_jgroups_initial_hosts:
+#   - "10.0.0.10[7600]"
+#   - "10.0.0.11[7600]"
+
+# Cache ownership
+keycloak_cache_owners: 2
+
+# Proxy / LB awareness (important for HA)
+keycloak_proxy_address_forwarding: true
+

--- a/roles/keycloak/tasks/keycloak.yml
+++ b/roles/keycloak/tasks/keycloak.yml
@@ -1,0 +1,165 @@
+---
+# Install & configure Keycloak (binary + config)
+
+# -------------------------------------------------------------------
+# Ensure base directory exists
+# -------------------------------------------------------------------
+- name: Ensure Keycloak base directory exists
+  ansible.builtin.file:
+    path: "{{ keycloak_base_dir }}"
+    state: directory
+    mode: "0755"
+
+# -------------------------------------------------------------------
+# Check if Keycloak version already extracted
+# -------------------------------------------------------------------
+- name: Check if Keycloak version already extracted
+  ansible.builtin.stat:
+    path: "{{ keycloak_versions_dir }}/keycloak-{{ keycloak_version }}"
+  register: kc_version_dir
+
+# -------------------------------------------------------------------
+# Download Keycloak archive (only if not extracted)
+# -------------------------------------------------------------------
+- name: Download Keycloak archive
+  ansible.builtin.get_url:
+    url: "{{ keycloak_download_url }}"
+    dest: "{{ keycloak_tmp_dir }}/{{ keycloak_archive_name }}"
+    mode: "0644"
+  when: not kc_version_dir.stat.exists
+
+# -------------------------------------------------------------------
+# Extract Keycloak (only if not extracted)
+# -------------------------------------------------------------------
+- name: Extract Keycloak archive
+  ansible.builtin.unarchive:
+    src: "{{ keycloak_tmp_dir }}/{{ keycloak_archive_name }}"
+    dest: "{{ keycloak_versions_dir }}"
+    remote_src: true
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+  when: not kc_version_dir.stat.exists
+
+# -------------------------------------------------------------------
+# Handle existing install path
+# -------------------------------------------------------------------
+- name: Check existing Keycloak install path
+  ansible.builtin.stat:
+    path: "{{ keycloak_install_dir }}"
+  register: kc_path
+
+- name: Backup existing Keycloak directory if not a symlink
+  ansible.builtin.command:
+    cmd: mv {{ keycloak_install_dir }} {{ keycloak_install_dir }}.bak
+  when:
+    - kc_path.stat.exists
+    - kc_path.stat.isdir
+    - not kc_path.stat.islnk
+
+# -------------------------------------------------------------------
+# Create symlink to current version
+# -------------------------------------------------------------------
+- name: Create Keycloak symlink to versioned directory
+  ansible.builtin.file:
+    src: "{{ keycloak_versions_dir }}/keycloak-{{ keycloak_version }}"
+    dest: "{{ keycloak_install_dir }}"
+    state: link
+    force: yes
+
+# -------------------------------------------------------------------
+# Configuration directory
+# -------------------------------------------------------------------
+- name: Ensure Keycloak config directory exists
+  ansible.builtin.file:
+    path: "{{ keycloak_install_dir }}/conf"
+    state: directory
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    mode: "0755"
+
+# -------------------------------------------------------------------
+# Render keycloak.conf
+# -------------------------------------------------------------------
+- name: Render Keycloak configuration file
+  ansible.builtin.template:
+    src: keycloak.conf.j2
+    dest: "{{ keycloak_install_dir }}/conf/keycloak.conf"
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    mode: "0644"
+
+# -------------------------------------------------------------------
+# Build Keycloak (Quarkus optimized runtime)
+# -------------------------------------------------------------------
+- name: Build Keycloak (Quarkus optimized)
+  ansible.builtin.command:
+    cmd: "{{ keycloak_versions_dir }}/keycloak-{{ keycloak_version }}/bin/kc.sh build"
+  become_user: "{{ keycloak_user }}"
+  args:
+    chdir: "{{ keycloak_versions_dir }}/keycloak-{{ keycloak_version }}"
+
+# -------------------------------------------------------------------
+# Ensure /etc/keycloak config directory exists
+# -------------------------------------------------------------------
+- name: Ensure /etc/keycloak directory exists
+  ansible.builtin.file:
+    path: /etc/keycloak
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# -------------------------------------------------------------------
+# Create Keycloak environment file (must exist BEFORE build)
+# -------------------------------------------------------------------
+- name: Create Keycloak environment file
+  ansible.builtin.template:
+    src: keycloak.env.j2
+    dest: /etc/keycloak/keycloak.env
+    owner: root
+    group: root
+    mode: "0600"
+
+# -------------------------------------------------------------------
+# Realm import directory (optional)
+# -------------------------------------------------------------------
+- name: Ensure realm import directory exists
+  ansible.builtin.file:
+    path: "{{ keycloak_install_dir }}/data/import"
+    state: directory
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    mode: "0755"
+  when:
+    - keycloak_identity_providers.oidc
+      or keycloak_identity_providers.ldap
+      or keycloak_identity_providers.saml
+
+# -------------------------------------------------------------------
+# Realm import for identity providers
+# -------------------------------------------------------------------
+- name: Render realm import file for identity providers
+  ansible.builtin.template:
+    src: realm-import.json.j2
+    dest: "{{ keycloak_install_dir }}/data/import/realm-import.json"
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    mode: "0644"
+  when:
+    - keycloak_identity_providers.oidc
+      or keycloak_identity_providers.ldap
+      or keycloak_identity_providers.saml
+
+
+# -------------------------------------------------------------------
+# High Availability
+# -------------------------------------------------------------------
+
+- name: Validate HA prerequisites
+  ansible.builtin.assert:
+    that:
+      - keycloak_manage_db == false
+      - keycloak_jgroups_initial_hosts | length > 0
+    fail_msg: >
+      HA mode requires external DB and jgroups initial hosts
+  when: keycloak_ha_enabled | bool

--- a/roles/keycloak/tasks/verify.yml
+++ b/roles/keycloak/tasks/verify.yml
@@ -1,0 +1,31 @@
+---
+# -------------------------------------------------------------------
+# Verify Keycloak service is running
+# -------------------------------------------------------------------
+- name: Verify Keycloak service is active
+  ansible.builtin.command:
+    cmd: systemctl is-active keycloak
+  register: kc_service_status
+  changed_when: false
+  failed_when: kc_service_status.stdout != "active"
+
+# -------------------------------------------------------------------
+# Informational: HTTPS configuration status
+# (No port waiting to avoid runtime TLS dependency)
+# -------------------------------------------------------------------
+- name: Show HTTPS configuration status
+  ansible.builtin.debug:
+    msg: >
+      Keycloak HTTPS is {{
+        'ENABLED' if (keycloak_https_enabled | default(false) | bool)
+        else 'DISABLED'
+      }}.
+      Runtime TLS binding depends on certificate validation.
+
+## High Availability (HA) Deployment
+
+- name: Show HA configuration status
+  ansible.builtin.debug:
+    msg: >
+      Keycloak HA is {{ 'ENABLED' if keycloak_ha_enabled else 'DISABLED' }}.
+      Cache stack={{ keycloak_cache_stack }}

--- a/roles/keycloak/templates/keycloak.conf.j2
+++ b/roles/keycloak/templates/keycloak.conf.j2
@@ -1,0 +1,47 @@
+# ---------------- DATABASE ----------------
+db=postgres
+db-url=jdbc:postgresql://{{ postgres_host }}:{{ postgres_port }}/{{ keycloak_db_name }}
+db-username={{ keycloak_db_user }}
+db-password={{ keycloak_db_password }}
+
+# ---------------- HTTP ----------------
+http-enabled=true
+http-port={{ keycloak_http_port }}
+http-host=0.0.0.0
+
+# ---------------- HTTPS ----------------
+{% if keycloak_https_enabled | bool %}
+https-enabled=true
+https-port={{ keycloak_https_port }}
+https-certificate-file={{ keycloak_tls_cert_file }}
+https-certificate-key-file={{ keycloak_tls_key_file }}
+{% endif %}
+
+# ---------------- HOSTNAME ----------------
+hostname={{ keycloak_hostname }}
+hostname-strict=false
+hostname-strict-https=false
+
+# ---------------- REVERSE PROXY ----------------
+{% if keycloak_proxy_mode != "none" %}
+proxy={{ keycloak_proxy_mode }}
+{% endif %}
+
+# ---------------- HA / Clustering ----------------
+{% if keycloak_ha_enabled | bool %}
+
+cache=ispn
+cache-stack={{ keycloak_cache_stack }}
+
+cluster-name=keycloak-cluster
+node-name={{ keycloak_node_name }}
+
+{% if keycloak_cache_stack == "tcp" %}
+jgroups.tcp.initial_hosts={{ keycloak_jgroups_initial_hosts | join(",") }}
+{% endif %}
+
+{% endif %}
+
+# ---------------- Proxy ----------------
+proxy={{ keycloak_proxy_mode }}
+proxy-address-forwarding={{ keycloak_proxy_address_forwarding | lower }}

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=Keycloak
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User={{ keycloak_user }}
+Group={{ keycloak_group }}
+
+# Load environment variables securely
+Environment="KC_NODE_NAME={{ keycloak_node_name }}"
+
+
+{% set idp_enabled = keycloak_identity_providers.oidc
+   or keycloak_identity_providers.ldap
+   or keycloak_identity_providers.saml %}
+
+# Keycloak Quarkus requires optimized mode for systemd
+ExecStart={{ keycloak_install_dir }}/bin/kc.sh start --optimized{% if idp_enabled %} --import-realm{% endif %}
+
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added HA-ready configuration support to Keycloak role including clustering, cache stack, node identity, and validation for external DB usage.